### PR TITLE
git: fix panic when bad target is given

### DIFF
--- a/git.go
+++ b/git.go
@@ -29,8 +29,12 @@ func initGit(mailSet mapset.Set) {
 func gitSearch(target string, WebsiteAPI string, mailSet mapset.Set) mapset.Set {
 	// TODO: add worker for pagination
 	domain := ""
-	targetSplit := strings.Split(target, "/")
 	commits := ""
+	targetSplit := strings.Split(target, "/")
+	if len(targetSplit) != 5 {
+		fmt.Println("You must specify a repository URL")
+		os.Exit(1)
+	}
 
 	fmt.Println("==== GIT SEARCH FOR " + target + " ==== ")
 


### PR DESCRIPTION
Hi,

While I was using gOSINT, I got a panic because I tried to give the URL of a company which has several repositories.
Because it is not covered, I added a little check before accessing the slice indexes!

Thanks,